### PR TITLE
Enable integration tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
      </dependency>
 ```
 
+## Running Integration tests in docker containers(Optional)
+
+The CDC functionality are tested with the docker base integration test framework.
+The test framework initialize a docker container with required configuration before execute the test suit.
+
+**Start integration tests**
+
+1. Install and run docker
+2. To run the integration test, navigate to the siddhi-io-cdc/ directory and issue the following command.
+```
+    mvn verify -P local-mysql
+```
+
 ## Jenkins Build Status
 
 ---

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -100,6 +100,100 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>local-mysql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start-docker-for-mysql</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop-docker-for-mysql</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>remove</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>siddhi-cdc-mysql</alias>
+                                    <name>mysql:5.7</name>
+                                    <run>
+                                        <volumes>
+                                            <bind>
+                                                <volume>
+                                                    src/test/resources/mysqld:/etc/mysql/conf.d
+                                                </volume>
+                                            </bind>
+                                        </volumes>
+                                        <namingStrategy>alias</namingStrategy>
+                                        <env>
+                                            <MYSQL_DATABASE>SimpleDB</MYSQL_DATABASE>
+                                            <MYSQL_ROOT_PASSWORD>root</MYSQL_ROOT_PASSWORD>
+                                        </env>
+                                        <ports>
+                                            <port>${siddhi-cdc-mysql.port}:3306</port>
+                                        </ports>
+                                        <wait>
+                                            <tcp>
+                                                <ports>
+                                                    <port>3306</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <executions>
+                            <execution>
+                                <id>integration-test-for-mysql</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>verify-for-mysql</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <environmentVariables>
+                                <DATABASE_TYPE>MySQL</DATABASE_TYPE>
+                                <DATABASE_USER>root</DATABASE_USER>
+                                <DATABASE_PASSWORD>root</DATABASE_PASSWORD>
+                                <PORT>${siddhi-cdc-mysql.port}</PORT>
+                                <DOCKER_HOST_IP>${docker.container.siddhi-cdc-mysql.ip}</DOCKER_HOST_IP>
+                            </environmentVariables>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
     <build>
         <resources>
@@ -117,6 +211,7 @@
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <skip>${skip.surefire.test}</skip>
                 </configuration>
             </plugin>
             <plugin>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -211,7 +211,7 @@
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <skip>${skip.surefire.test}</skip>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
             <plugin>

--- a/component/src/test/java/org/wso2/extension/siddhi/io/cdc/source/TestCaseOfCDCSource.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/cdc/source/TestCaseOfCDCSource.java
@@ -20,6 +20,7 @@ package org.wso2.extension.siddhi.io.cdc.source;
 
 import org.apache.log4j.Logger;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
@@ -43,11 +44,20 @@ public class TestCaseOfCDCSource {
     private AtomicBoolean eventArrived = new AtomicBoolean(false);
     private int waitTime = 50;
     private int timeout = 10000;
-    private String username = "";
-    private String password = "";
+    private String username;
+    private String password;
     private String jdbcDriverName = "com.mysql.jdbc.Driver";
-    private String databaseURL = "jdbc:mysql://localhost:3306/SimpleDB";
+    private String databaseURL;
     private String tableName = "login";
+
+    @BeforeClass
+    public void initializeConnectionParams() {
+        String port = System.getenv("PORT");
+        String host = System.getenv("DOCKER_HOST_IP");
+        databaseURL = "jdbc:mysql://" + host + ":" + port + "/SimpleDB?useSSL=false";
+        username = System.getenv("DATABASE_USER");
+        password = System.getenv("DATABASE_PASSWORD");
+    }
 
     @BeforeMethod
     public void init() {

--- a/component/src/test/resources/mysqld/mysqld.cnf
+++ b/component/src/test/resources/mysqld/mysqld.cnf
@@ -1,0 +1,104 @@
+#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+# 
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+[mysqld_safe]
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
+lc-messages-dir	= /usr/share/mysql
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+bind-address		= 0.0.0.0
+#
+# * Fine Tuning
+#
+key_buffer_size		= 16M
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size       = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover-options  = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+#thread_concurrency     = 10
+#
+# * Query Cache Configuration
+#
+query_cache_limit	= 1M
+query_cache_size        = 16M
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+#log_slow_queries	= /var/log/mysql/mysql-slow.log
+#long_query_time = 2
+#log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+server-id		= 1
+log_bin			= /var/log/mysql/mysql-bin.log
+expire_logs_days	= 10
+max_binlog_size   = 100M
+#binlog_do_db		= include_database_name
+#binlog_ignore_db	= include_database_name
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -25,7 +25,7 @@
     Uncomment the following test to run with build.-->
     <test name="Siddhi-io-cdc-tests" enabled="true">
         <classes>
-            <!--<class name="org.wso2.extension.siddhi.io.cdc.source.TestCaseOfCDCSource"/>-->
+            <class name="org.wso2.extension.siddhi.io.cdc.source.TestCaseOfCDCSource"/>
         </classes>
     </test>
 </suite>

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v1.0.3
+# API Docs - v1.0.4-SNAPSHOT
 
 ## Source
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,19 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
      </dependency>
 ```
 
+## Running Integration tests in docker containers(Optional)
+
+The CDC functionality are tested with the docker base integration test framework.
+The test framework initialize a docker container with required configuration before execute the test suit.
+
+**Start integration tests**
+
+1. Install and run docker
+2. To run the integration test, navigate to the siddhi-io-cdc/ directory and issue the following command.
+```
+    mvn verify -P local-mysql
+```
+
 ## Jenkins Build Status
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,8 @@
         <debezium-connector-oracle.version>0.8.3.Final</debezium-connector-oracle.version>
         <org.testng.version>6.11</org.testng.version>
         <siddhi-store-rdbms.version>4.0.39</siddhi-store-rdbms.version>
+        <siddhi-cdc-mysql.port>3309</siddhi-cdc-mysql.port>
+        <docker.container.siddhi-cdc-mysql.ip>0.0.0.0</docker.container.siddhi-cdc-mysql.ip>
     </properties>
     <scm>
         <url>https://github.com/wso2-extensions/siddhi-io-cdc.git</url>


### PR DESCRIPTION
## Purpose
> The siddhi-io-cdc extension's functionality needs to be tested against a well-configured MySQL instance.

## Goals
> Adding Docker container based MySQL database which will start before the test. Thus the user/developer doesn't need to manually configure MySQL for the integration testing.

## Approach
> Use fabric8 maven plugin to start a MySQL docker container before tests. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> OS: Ubuntu 16.04 LTS
Docker version: 18.09.0
Java version: 1.8.0_181
Apache Maven version: 3.3.9

MySQL:5.7 base image is used for the integration testing.